### PR TITLE
Gitlab v10.1.1 Release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/sameersbn/gitlab:10.0.3
+FROM quay.io/sameersbn/gitlab:10.1.1
 MAINTAINER Rohith <gambol99@gmail.com>
 
 RUN apt update -y && \


### PR DESCRIPTION
This is the last version we can upgrade to before breaking change introduced in https://gitlab.com/gitlab-org/gitlab-ce/merge_requests/15226/diffs (and released in 10.1.2 - https://gitlab.com/gitlab-org/gitlab-ce/blob/master/CHANGELOG.md#1012-2017-11-08). 

Need to find workaround for that before future upgrades. Might be related to RDS setup.